### PR TITLE
Use text_type instead str

### DIFF
--- a/pyramid_sacrud/resources.py
+++ b/pyramid_sacrud/resources.py
@@ -9,6 +9,7 @@
 """
 Resources of pyramid_sacrud
 """
+from pyramid.compat import text_type
 
 
 class GroupResource(object):
@@ -25,4 +26,4 @@ class GroupResource(object):
 
     @property
     def __name__(self):
-        return str(self.group)
+        return text_type(self.group)

--- a/pyramid_sacrud/routes.py
+++ b/pyramid_sacrud/routes.py
@@ -13,12 +13,13 @@ Routes for pyramid_sacrud
 from . import CONFIG_RESOURCES, PYRAMID_SACRUD_HOME, PYRAMID_SACRUD_VIEW
 from .resources import GroupResource
 from pyramid.events import ApplicationCreated
+from pyramid.compat import text_type
 
 
 def admin_factory(request):
     config = request.registry.settings[CONFIG_RESOURCES]
     return {
-        str(group): GroupResource(group, resources)
+        text_type(group): GroupResource(group, resources)
         for group, resources in config
     }
 


### PR DESCRIPTION
This PR adds ability to use non latin group names without i18n machinery.